### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/data/Introducing-pgzx--create-PostgreSQL-extensions-using-Zig.yaml
+++ b/data/Introducing-pgzx--create-PostgreSQL-extensions-using-Zig.yaml
@@ -280,7 +280,7 @@
   prefs: []
   type: TYPE_PRE
   zh: '[PRE7]'
-- en: 'pgzx comes with a [Nix flakes](https://nixos.wiki/wiki/Flakes) based development
+- en: 'pgzx comes with a [Nix flakes](https://wiki.nixos.org/wiki/Flakes) based development
     environment for developing extensions as well as pgzx itself. It also comes with
     a project template which you can use to set up this environment in a new repository.
     To use it, [install Nix](https://github.com/DeterminateSystems/nix-installer)
@@ -288,7 +288,7 @@
   id: totrans-split-39
   prefs: []
   type: TYPE_NORMAL
-  zh: pgzx提供了一个基于[Nix flakes](https://nixos.wiki/wiki/Flakes)的开发环境，用于开发扩展以及pgzx本身。它还提供了一个项目模板，您可以在新的存储库中使用它来设置这个环境。要使用它，[安装Nix](https://github.com/DeterminateSystems/nix-installer)，然后运行：
+  zh: pgzx提供了一个基于[Nix flakes](https://wiki.nixos.org/wiki/Flakes)的开发环境，用于开发扩展以及pgzx本身。它还提供了一个项目模板，您可以在新的存储库中使用它来设置这个环境。要使用它，[安装Nix](https://github.com/DeterminateSystems/nix-installer)，然后运行：
 - en: '[PRE8]'
   id: totrans-split-40
   prefs: []

--- a/data/Nix-shell-shebang---NixOS-Wiki.yaml
+++ b/data/Nix-shell-shebang---NixOS-Wiki.yaml
@@ -24,12 +24,12 @@
   - PREF_H1
   type: TYPE_NORMAL
   zh: Nix-shell shebang - NixOS Wiki
-- en: 来源：[https://nixos.wiki/wiki/Nix-shell_shebang](https://nixos.wiki/wiki/Nix-shell_shebang)
+- en: 来源：[https://wiki.nixos.org/wiki/Nix-shell_shebang](https://wiki.nixos.org/wiki/Nix-shell_shebang)
   id: totrans-split-5
   prefs:
   - PREF_BQ
   type: TYPE_NORMAL
-  zh: 来源：[https://nixos.wiki/wiki/Nix-shell_shebang](https://nixos.wiki/wiki/Nix-shell_shebang)
+  zh: 来源：[https://wiki.nixos.org/wiki/Nix-shell_shebang](https://wiki.nixos.org/wiki/Nix-shell_shebang)
 - en: You can use `nix-shell` as a script interpreter to
   id: totrans-split-6
   prefs: []

--- a/data/So-You-Want-to-Ship-a-Command-Line-Tool-for-macOS---rebecca-.yaml
+++ b/data/So-You-Want-to-Ship-a-Command-Line-Tool-for-macOS---rebecca-.yaml
@@ -56,12 +56,12 @@
   type: TYPE_NORMAL
   zh: 我们使用GitHub actions构建和发布发布版本，这样工程师们可以在需要设置新机器或修复现有机器的开发环境时下载并运行最新版本的工具。
 - en: On Linux, this is all fine and dandy ([the usual headaches with running anything
-    on NixOS aside](https://nixos.wiki/wiki/Packaging/Binaries)), but macOS requires
+    on NixOS aside](https://wiki.nixos.org/wiki/Packaging/Binaries)), but macOS requires
     that programs be code signed and notarized.
   id: totrans-split-10
   prefs: []
   type: TYPE_NORMAL
-  zh: 在Linux上，这些都很顺利（除了在NixOS上运行任何东西的通常问题之外](https://nixos.wiki/wiki/Packaging/Binaries)，但macOS要求程序必须经过代码签名和公证。
+  zh: 在Linux上，这些都很顺利（除了在NixOS上运行任何东西的通常问题之外](https://wiki.nixos.org/wiki/Packaging/Binaries)，但macOS要求程序必须经过代码签名和公证。
 - en: 'Code signing on macOS is a *nightmare.* Knowing a little bit about asymmetric
     encryption, I expected the process to be roughly like this:'
   id: totrans-split-11

--- a/docs/2402/Nix-shell-shebang---NixOS-Wiki.md
+++ b/docs/2402/Nix-shell-shebang---NixOS-Wiki.md
@@ -8,7 +8,7 @@
 
 # Nix-shell shebang - NixOS Wiki
 
-> 来源：[https://nixos.wiki/wiki/Nix-shell_shebang](https://nixos.wiki/wiki/Nix-shell_shebang)
+> 来源：[https://wiki.nixos.org/wiki/Nix-shell_shebang](https://wiki.nixos.org/wiki/Nix-shell_shebang)
 
 您可以使用 `nix-shell` 作为脚本解释器来
 

--- a/docs/2402/So-You-Want-to-Ship-a-Command-Line-Tool-for-macOS---rebecca-.md
+++ b/docs/2402/So-You-Want-to-Ship-a-Command-Line-Tool-for-macOS---rebecca-.md
@@ -18,7 +18,7 @@ date: 2024-05-27 15:04:02
 
 我们使用GitHub actions构建和发布发布版本，这样工程师们可以在需要设置新机器或修复现有机器的开发环境时下载并运行最新版本的工具。
 
-在Linux上，这些都很顺利（除了在NixOS上运行任何东西的通常问题之外](https://nixos.wiki/wiki/Packaging/Binaries)，但macOS要求程序必须经过代码签名和公证。
+在Linux上，这些都很顺利（除了在NixOS上运行任何东西的通常问题之外](https://wiki.nixos.org/wiki/Packaging/Binaries)，但macOS要求程序必须经过代码签名和公证。
 
 在macOS上进行代码签名真的是一场*噩梦*。作为对非对称加密略有了解的人，我本来以为过程大致是这样的：
 

--- a/docs/2402/done/A-look-at-Nix-and-Guix--LWN-net-.yaml
+++ b/docs/2402/done/A-look-at-Nix-and-Guix--LWN-net-.yaml
@@ -168,7 +168,7 @@
     on the package definitions in nixpkgs, they are likely to be able to download
     a cached output for the derivation from Hydra. NixOS refers to itself as a mixed
     source/binary distribution because of this — users can build software from scratch
-    (including [tuning the build flags](https://nixos.wiki/wiki/Build_flags) for their
+    (including [tuning the build flags](https://wiki.nixos.org/wiki/Build_flags) for their
     system, as can be done by Gentoo users), but most users just download binary versions
     of most of their packages, and know that they're getting the same result as having
     built from scratch.
@@ -176,7 +176,7 @@
   prefs: []
   type: TYPE_NORMAL
   zh: Nixpkgs包含超过80000个软件包的定义。这些软件包由[NixOS构建农场](https://hydra.nixos.org/build/248007843/download/1/hydra/)Hydra构建、缓存和共享。因此，尽管NixOS配置描述了如何从头开始获取和构建所有选定的软件，但如果用户依赖于nixpkgs中的软件包定义，则他们可能能够从Hydra下载派生物的缓存输出。由于这一点，NixOS将自己称为混合源/二进制分发
-    —— 用户可以从头开始构建软件（包括[调整构建标志](https://nixos.wiki/wiki/Build_flags)以适应其系统，就像Gentoo用户可以做的那样），但大多数用户只是下载大多数软件包的二进制版本，并且知道他们得到的结果与从头开始构建的结果相同。
+    —— 用户可以从头开始构建软件（包括[调整构建标志](https://wiki.nixos.org/wiki/Build_flags)以适应其系统，就像Gentoo用户可以做的那样），但大多数用户只是下载大多数软件包的二进制版本，并且知道他们得到的结果与从头开始构建的结果相同。
 - en: Multiple versions
   id: totrans-20
   prefs:

--- a/docs/2403/Introducing-pgzx--create-PostgreSQL-extensions-using-Zig.md
+++ b/docs/2403/Introducing-pgzx--create-PostgreSQL-extensions-using-Zig.md
@@ -172,7 +172,7 @@ if (errctx.pg_try()) {
 } 
 ```
 
-pgzx提供了一个基于[Nix flakes](https://nixos.wiki/wiki/Flakes)的开发环境，用于开发扩展以及pgzx本身。它还提供了一个项目模板，您可以在新的存储库中使用它来设置这个环境。要使用它，[安装Nix](https://github.com/DeterminateSystems/nix-installer)，然后运行：
+pgzx提供了一个基于[Nix flakes](https://wiki.nixos.org/wiki/Flakes)的开发环境，用于开发扩展以及pgzx本身。它还提供了一个项目模板，您可以在新的存储库中使用它来设置这个环境。要使用它，[安装Nix](https://github.com/DeterminateSystems/nix-installer)，然后运行：
 
 ```
 mkdir my_extension


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️